### PR TITLE
Make bsw128 variant (mostly) bootable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 GEOS64.D64
+GEOS128.D64
 desktop.cvt
 build

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,10 @@ DESKTOP_CVT  = desktop.cvt
 
 ifeq ($(VARIANT),bsw128)
 D64_TEMPLATE = GEOS128.D64
+DESKTOP_CVT  = desktop.cvt
 else
 D64_TEMPLATE = GEOS64.D64
+DESKTOP_CVT  = 128 desktop.cvt
 endif
 
 ASFLAGS      = -I inc -I .
@@ -305,9 +307,9 @@ $(BUILD_DIR)/$(D64_RESULT): $(BUILD_DIR)/kernal_compressed.prg
 		echo write $< geos128 | $(C1541) $@ ;\
 		echo \*\*\* Created $@ based on $(D64_TEMPLATE).; \
 	else \
-		echo format geos,00 d64 $@ | $(C1541) >/dev/null; \
-		echo write $< geos128 | $(C1541) $@ >/dev/null; \
-		if [ -e $(DESKTOP_CVT) ]; then echo geoswrite $(DESKTOP_CVT) | $(C1541) $@; fi >/dev/null; \
+		echo format geos,00 d64 $@ | $(C1541); \
+		echo write $< geos128 | $(C1541) $@; \
+		if [ -e "$(DESKTOP_CVT)" ]; then echo geoswrite "$(DESKTOP_CVT)" | $(C1541) $@; fi; \
 		echo \*\*\* Created fresh $@.; \
 	fi;
 else

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,15 @@ AS           = ca65
 LD           = ld65
 C1541        = c1541
 PUCRUNCH     = pucrunch
-D64_TEMPLATE = GEOS64.D64
+EXOMIZER     = exomizer
 D64_RESULT   = geos.d64
 DESKTOP_CVT  = desktop.cvt
+
+ifeq ($(VARIANT),bsw128)
+D64_TEMPLATE = GEOS128.D64
+else
+D64_TEMPLATE = GEOS64.D64
+endif
 
 ASFLAGS      = -I inc -I .
 
@@ -291,11 +297,25 @@ regress:
 clean:
 	rm -rf build
 
+ifeq ($(VARIANT),bsw128)
 $(BUILD_DIR)/$(D64_RESULT): $(BUILD_DIR)/kernal_compressed.prg
 	@if [ -e $(D64_TEMPLATE) ]; then \
 		cp $(D64_TEMPLATE) $@; \
-		echo delete geos geoboot | $(C1541) $@ >/dev/null; \
-		echo write $< geos | $(C1541) $@ >/dev/null; \
+		echo delete geos128 geoboot128 | $(C1541) $@ ;\
+		echo write $< geos128 | $(C1541) $@ ;\
+		echo \*\*\* Created $@ based on $(D64_TEMPLATE).; \
+	else \
+		echo format geos,00 d64 $@ | $(C1541) >/dev/null; \
+		echo write $< geos128 | $(C1541) $@ >/dev/null; \
+		if [ -e $(DESKTOP_CVT) ]; then echo geoswrite $(DESKTOP_CVT) | $(C1541) $@; fi >/dev/null; \
+		echo \*\*\* Created fresh $@.; \
+	fi;
+else
+$(BUILD_DIR)/$(D64_RESULT): $(BUILD_DIR)/kernal_compressed.prg
+	@if [ -e $(D64_TEMPLATE) ]; then \
+		cp $(D64_TEMPLATE) $@; \
+		echo delete geos geoboot | $(C1541) $@ ;\
+		echo write $< geos | $(C1541) $@ ;\
 		echo \*\*\* Created $@ based on $(D64_TEMPLATE).; \
 	else \
 		echo format geos,00 d64 $@ | $(C1541) >/dev/null; \
@@ -303,12 +323,14 @@ $(BUILD_DIR)/$(D64_RESULT): $(BUILD_DIR)/kernal_compressed.prg
 		if [ -e $(DESKTOP_CVT) ]; then echo geoswrite $(DESKTOP_CVT) | $(C1541) $@; fi >/dev/null; \
 		echo \*\*\* Created fresh $@.; \
 	fi;
+endif
 
 $(BUILD_DIR)/kernal_compressed.prg: $(BUILD_DIR)/kernal_combined.prg
 	@echo Creating $@
 ifeq ($(VARIANT), bsw128)
-	# pucrunch can't compress for C128 :(
-	cp $< $@
+	# start address ($4800) is underneath BASIC ROM on the 128; turn off BASIC
+	# and KERNAL before jumping to unpacked code
+	$(EXOMIZER) sfx 0x4800 -t128 -Di_ram_exit='$$3e' -o $@ $<
 else
 	$(PUCRUNCH) -f -c64 -x0x5000 $< $@ 2> /dev/null
 endif
@@ -321,8 +343,12 @@ ifeq ($(VARIANT), bsw128)
 	cat $(BUILD_DIR)/kernal/relocator.bin /dev/zero | dd bs=1 count=1024 >> $(BUILD_DIR)/tmp.bin 2> /dev/null
 # kernal.bin($5000)    @ $5000-$5400 -> $4C00
 	cat $(BUILD_DIR)/kernal/kernal.bin /dev/zero | dd bs=1 count=1024 >> $(BUILD_DIR)/tmp.bin 2> /dev/null
-# kernal.bin($5000)    @ $C000-$0000 -> $5000
-	cat $(BUILD_DIR)/kernal/kernal.bin /dev/zero | dd bs=1 count=16384 skip=28672 >> $(BUILD_DIR)/tmp.bin 2> /dev/null
+# kernal.bin($5000)    @ $C000-$FD00 -> $5000
+	cat $(BUILD_DIR)/kernal/kernal.bin /dev/zero | dd bs=1 count=15616 skip=28672 >> $(BUILD_DIR)/tmp.bin 2> /dev/null
+# input*.bin($FD00)    @ $FD00-$FE80 -> $8D00
+	cat $(BUILD_DIR)/input/$(INPUT).bin /dev/zero | dd bs=1 count=384 >> $(BUILD_DIR)/tmp.bin 2> /dev/null
+# kernal.bin($5000)    @ $FE80-$0000 -> $8E80
+	cat $(BUILD_DIR)/kernal/kernal.bin /dev/zero | dd bs=1 count=384 skip=44672 >> $(BUILD_DIR)/tmp.bin 2> /dev/null
 # drv*.bin($9000)      @ $9000-$9D80 -> $9000
 	cat $(BUILD_DIR)/drv/$(DRIVE).bin /dev/zero | dd bs=1 count=3456 >> $(BUILD_DIR)/tmp.bin 2> /dev/null
 # kernal.bin($5000)    @ $9D80-$A000 -> $9D80
@@ -344,6 +370,12 @@ else
 	@mv $(BUILD_DIR)/tmp.bin $(BUILD_DIR)/kernal_combined.prg
 endif
 
+ifeq ($(VARIANT),bsw128)
+INPUTCFG = input/inputdrv_bsw128.cfg
+else
+INPUTCFG = input/inputdrv.cfg
+endif
+
 $(BUILD_DIR)/drv/drv1541.bin: $(BUILD_DIR)/drv/drv1541.o drv/drv1541.cfg $(DEPS)
 	$(LD) -C drv/drv1541.cfg $(BUILD_DIR)/drv/drv1541.o -o $@
 
@@ -353,23 +385,23 @@ $(BUILD_DIR)/drv/drv1571.bin: $(BUILD_DIR)/drv/drv1571.o drv/drv1571.cfg $(DEPS)
 $(BUILD_DIR)/drv/drv1581.bin: $(BUILD_DIR)/drv/drv1581.o drv/drv1581.cfg $(DEPS)
 	$(LD) -C drv/drv1581.cfg $(BUILD_DIR)/drv/drv1581.o -o $@
 
-$(BUILD_DIR)/input/amigamse.bin: $(BUILD_DIR)/input/amigamse.o input/amigamse.cfg $(DEPS)
-	$(LD) -C input/amigamse.cfg $(BUILD_DIR)/input/amigamse.o -o $@
+$(BUILD_DIR)/input/amigamse.bin: $(BUILD_DIR)/input/amigamse.o $(INPUTCFG) $(DEPS)
+	$(LD) -C $(INPUTCFG) $(BUILD_DIR)/input/amigamse.o -o $@
 
-$(BUILD_DIR)/input/joydrv.bin: $(BUILD_DIR)/input/joydrv.o input/joydrv.cfg $(DEPS)
-	$(LD) -C input/joydrv.cfg $(BUILD_DIR)/input/joydrv.o -o $@
+$(BUILD_DIR)/input/joydrv.bin: $(BUILD_DIR)/input/joydrv.o $(INPUTCFG) $(DEPS)
+	$(LD) -C $(INPUTCFG) $(BUILD_DIR)/input/joydrv.o -o $@
 
-$(BUILD_DIR)/input/lightpen.bin: $(BUILD_DIR)/input/lightpen.o input/lightpen.cfg $(DEPS)
-	$(LD) -C input/lightpen.cfg $(BUILD_DIR)/input/lightpen.o -o $@
+$(BUILD_DIR)/input/lightpen.bin: $(BUILD_DIR)/input/lightpen.o $(INPUTCFG) $(DEPS)
+	$(LD) -C $(INPUTCFG) $(BUILD_DIR)/input/lightpen.o -o $@
 
-$(BUILD_DIR)/input/mse1531.bin: $(BUILD_DIR)/input/mse1531.o input/mse1531.cfg $(DEPS)
-	$(LD) -C input/mse1531.cfg $(BUILD_DIR)/input/mse1531.o -o $@
+$(BUILD_DIR)/input/mse1531.bin: $(BUILD_DIR)/input/mse1531.o $(INPUTCFG) $(DEPS)
+	$(LD) -C $(INPUTCFG) $(BUILD_DIR)/input/mse1531.o -o $@
 
-$(BUILD_DIR)/input/koalapad.bin: $(BUILD_DIR)/input/koalapad.o input/koalapad.cfg $(DEPS)
-	$(LD) -C input/koalapad.cfg $(BUILD_DIR)/input/koalapad.o -o $@
+$(BUILD_DIR)/input/koalapad.bin: $(BUILD_DIR)/input/koalapad.o $(INPUTCFG) $(DEPS)
+	$(LD) -C $(INPUTCFG) $(BUILD_DIR)/input/koalapad.o -o $@
 
-$(BUILD_DIR)/input/pcanalog.bin: $(BUILD_DIR)/input/pcanalog.o input/pcanalog.cfg $(DEPS)
-	$(LD) -C input/pcanalog.cfg $(BUILD_DIR)/input/pcanalog.o -o $@
+$(BUILD_DIR)/input/pcanalog.bin: $(BUILD_DIR)/input/pcanalog.o $(INPUTCFG) $(DEPS)
+	$(LD) -C $(INPUTCFG) $(BUILD_DIR)/input/pcanalog.o -o $@
 
 $(BUILD_DIR)/%.o: %.s
 	@mkdir -p `dirname $@`

--- a/input/amigamse.cfg
+++ b/input/amigamse.cfg
@@ -1,7 +1,0 @@
-MEMORY {
-	MOUSE_BASE:    start = $FE80, size = $0180, file = %O;
-}
-
-SEGMENTS {
-	amigamse: load = MOUSE_BASE, type = ro;
-}

--- a/input/amigamse.s
+++ b/input/amigamse.s
@@ -17,6 +17,10 @@ SlowMouse:
 	jmp _SlowMouse
 UpdateMouse:
 	jmp _UpdateMouse
+.ifdef bsw128
+SetMouse:
+	rts
+.endif
 
 acceleration:
 	.byte 3

--- a/input/amigamse.s
+++ b/input/amigamse.s
@@ -9,7 +9,7 @@
 .include "jumptab.inc"
 .include "c64.inc"
 
-.segment "amigamse"
+.segment "inputdrv"
 
 MouseInit:
 	jmp _MouseInit

--- a/input/inputdrv.cfg
+++ b/input/inputdrv.cfg
@@ -3,5 +3,5 @@ MEMORY {
 }
 
 SEGMENTS {
-	lightpen: load = MOUSE_BASE, type = ro;
+	inputdrv: load = MOUSE_BASE, type = ro;
 }

--- a/input/inputdrv_bsw128.cfg
+++ b/input/inputdrv_bsw128.cfg
@@ -1,0 +1,8 @@
+MEMORY {
+#	MOUSE_BASE:    start = $FE80, size = $0180, file = %O;
+	MOUSE_BASE:    start = $FD00, size = $0180, file = %O;
+}
+
+SEGMENTS {
+	inputdrv: load = MOUSE_BASE, type = ro;
+}

--- a/input/joydrv.cfg
+++ b/input/joydrv.cfg
@@ -1,7 +1,0 @@
-MEMORY {
-	MOUSE_BASE:    start = $FE80, size = $0180, file = %O;
-}
-
-SEGMENTS {
-	joydrv: load = MOUSE_BASE, type = ro;
-}

--- a/input/joydrv.s
+++ b/input/joydrv.s
@@ -9,7 +9,7 @@
 .include "jumptab.inc"
 .include "c64.inc"
 
-.segment "joydrv"
+.segment "inputdrv"
 
 MouseInit:
 	jmp _MouseInit

--- a/input/joydrv.s
+++ b/input/joydrv.s
@@ -17,7 +17,10 @@ SlowMouse:
 	jmp _SlowMouse
 UpdateMouse:
 	jmp _UpdateMouse
+.ifdef bsw128
 SetMouse:
+	rts
+.endif
 
 joyStat0:
 	.byte 0

--- a/input/koalapad.cfg
+++ b/input/koalapad.cfg
@@ -1,7 +1,0 @@
-MEMORY {
-	MOUSE_BASE:    start = $FE80, size = $0180, file = %O;
-}
-
-SEGMENTS {
-	koalapad: load = MOUSE_BASE, type = ro;
-}

--- a/input/koalapad.s
+++ b/input/koalapad.s
@@ -5,7 +5,7 @@
 
 ; TODO: reassemble
 
-.segment "koalapad"
+.segment "inputdrv"
 
 .byte $4c, $90, $fe, $4c, $9a, $fe, $4c, $9b, $fe, $00, $08, $08, $00, $00, $00, $00
 .byte $a9, $00, $85, $3b, $a9, $08, $85, $3a, $85, $3c, $60, $24, $30, $30, $03, $4c

--- a/input/lightpen.s
+++ b/input/lightpen.s
@@ -10,7 +10,7 @@
 .include "jumptab.inc"
 .include "c64.inc"
 
-.segment "lightpen"
+.segment "inputdrv"
 
 MouseInit:
 	jmp _MouseInit

--- a/input/lightpen.s
+++ b/input/lightpen.s
@@ -18,7 +18,10 @@ SlowMouse:
 	jmp _SlowMouse
 UpdateMouse:
 	jmp _UpdateMouse
+.ifdef bsw128
 SetMouse:
+	rts
+.endif
 
 calibMark:
 	.byte 0

--- a/input/mse1531.cfg
+++ b/input/mse1531.cfg
@@ -1,7 +1,0 @@
-MEMORY {
-	MOUSE_BASE:    start = $FE80, size = $0180, file = %O;
-}
-
-SEGMENTS {
-	mse1531: load = MOUSE_BASE, type = ro;
-}

--- a/input/mse1531.s
+++ b/input/mse1531.s
@@ -16,7 +16,10 @@ SlowMouse:
 	jmp _SlowMouse
 UpdateMouse:
 	jmp _UpdateMouse
+.ifdef bsw128
 SetMouse:
+	rts
+.endif
 
 tmpFire:
 	.byte 0

--- a/input/mse1531.s
+++ b/input/mse1531.s
@@ -8,7 +8,7 @@
 .include "geosmac.inc"
 .include "c64.inc"
 
-.segment "mse1531"
+.segment "inputdrv"
 
 MouseInit:
 	jmp _MouseInit

--- a/input/pcanalog.cfg
+++ b/input/pcanalog.cfg
@@ -1,7 +1,0 @@
-MEMORY {
-	MOUSE_BASE:    start = $FE80, size = $0180, file = %O;
-}
-
-SEGMENTS {
-	pcanalog: load = MOUSE_BASE, type = ro;
-}

--- a/input/pcanalog.s
+++ b/input/pcanalog.s
@@ -3,7 +3,7 @@
 ;
 ; pcanalog input driver
 
-.segment "pcanalog"
+.segment "inputdrv"
 
 .byte $4c, $94, $fe, $4c, $a0, $fe, $4c, $a1, $fe, $00, $2d, $33, $39, $07, $05, $39
 .byte $3e, $43, $08, $04, $a9, $00, $85, $3b, $a9, $00, $85, $3a, $a9, $00, $85, $3c


### PR DESCRIPTION
Initial groundwork to make the `bsw128` variant bootable:

- Pack with `exomizer` since `pucrunch` doesn't support C128 as a target

- Add Makefile logic to build C128 boot disks from masters available at http://cbmfiles.com

- Create input driver linker config for C128 and consolidate all input drivers under the same segment name

- Add `SetMouse` vector to input drivers when building for C128

Currently this version only boots if built with the `drv1571` disk driver (and a 1571 is used as the boot device). I haven't gotten to the bottom of this issue yet, but I thought I'd get a PR out.