### PR TITLE
correct wheels optimization conditions to make custom build work

### DIFF
--- a/kernal/dlgbox/dlgbox1b.s
+++ b/kernal/dlgbox/dlgbox1b.s
@@ -20,7 +20,7 @@
 .import DBDoVARSTR
 .import DBDoTXTSTR
 .import DBDoIcons
-.ifdef wheels
+.ifdef wheels_fixes
 .import DoESC_RULER
 .endif
 

--- a/kernal/dlgbox/dlgbox1e2.s
+++ b/kernal/dlgbox/dlgbox1e2.s
@@ -28,9 +28,11 @@
 .global DBIcOPEN
 .global DBKeyVector
 
-.ifdef wheels
+.ifdef wheels_size
 .global DBKeyVector2
 .global DBStringFaultVec2
+.endif
+.ifdef wheels
 .global DoKeyboardShortcut
 .endif
 

--- a/kernal/dlgbox/dlgbox1g.s
+++ b/kernal/dlgbox/dlgbox1g.s
@@ -10,7 +10,7 @@
 .include "kernal.inc"
 .include "c64.inc"
 
-.ifdef wheels
+.ifdef wheels_size
 .import StringGetNext
 .import DBStringFaultVec2
 .endif

--- a/kernal/dlgbox/dlgbox1h.s
+++ b/kernal/dlgbox/dlgbox1h.s
@@ -33,12 +33,14 @@
 .import GetString
 .import PutString
 
+.ifdef wheels_size
+.import DBKeyVector2
+.endif
 .ifdef wheels
 .import SetupRAMOpCall
 .import RstrKernal
 .import GetFEntries
 .import GetNewKernal
-.import DBKeyVector2
 .import FetchRAM
 .import CopyString
 .endif
@@ -49,7 +51,7 @@
 .global DBDoTXTSTR
 .global DBDoVARSTR
 
-.ifdef wheels
+.ifdef wheels_size
 .global StringGetNext
 .endif
 

--- a/kernal/files/files1a2a.s
+++ b/kernal/files/files1a2a.s
@@ -23,7 +23,9 @@ Add2:
         sta     r6L
         bcc     @1
         inc     r6H
-@1:	rts
+@1:
+Add2_return:
+	rts
 .else
 	AddVW 2, r6
 Add2_return:

--- a/kernal/process/process2.s
+++ b/kernal/process/process2.s
@@ -15,7 +15,7 @@
 .import TimersCMDs
 .import NumTimers
 
-.ifdef wheels
+.ifdef wheels_size
 .import EnableProcess
 .endif
 

--- a/kernal/process/process3a.s
+++ b/kernal/process/process3a.s
@@ -22,7 +22,7 @@
 .import _DoExecDelay
 .import _RemoveDelay
 
-.ifdef wheels
+.ifdef wheels_size
 .import UnfreezeProcess
 .import UnblockProcess
 .endif


### PR DESCRIPTION
Some symbols were guarded by `wheels` conditions rather than `wheels_fixes`/`wheels_size`